### PR TITLE
SVG logging

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -19,6 +19,10 @@
 
 #define	INTERVAL		400
 #define WAIT	vTaskDelay(INTERVAL)
+//#define SVG_LOGGING
+#ifdef SVG_LOGGING
+static char *svg_cut_line = "cut-cut-cut-cut";
+#endif
 
 static const char *TAG = "ST7789";
 
@@ -102,7 +106,7 @@ TickType_t ArrowTest(TFT_t * dev, FontxFile *fx, int width, int height) {
 	uint8_t fontHeight;
 	GetFontx(fx, 0, buffer, &fontWidth, &fontHeight);
 	//ESP_LOGI(__FUNCTION__,"fontWidth=%d fontHeight=%d",fontWidth,fontHeight);
-	
+
 	uint16_t xpos;
 	uint16_t ypos;
 	int	stlen;
@@ -840,7 +844,7 @@ void ST7789(void *pvParameters)
 	InitFontx(fx16M,"/spiffs/ILMH16XB.FNT",""); // 8x16Dot Mincyo
 	InitFontx(fx24M,"/spiffs/ILMH24XB.FNT",""); // 12x24Dot Mincyo
 	InitFontx(fx32M,"/spiffs/ILMH32XB.FNT",""); // 16x32Dot Mincyo
-	
+
 	TFT_t dev;
 	spi_master_init(&dev, CONFIG_MOSI_GPIO, CONFIG_SCLK_GPIO, CONFIG_CS_GPIO, CONFIG_DC_GPIO, CONFIG_RESET_GPIO, CONFIG_BL_GPIO);
 	lcdInit(&dev, CONFIG_WIDTH, CONFIG_HEIGHT, CONFIG_OFFSETX, CONFIG_OFFSETY);
@@ -882,80 +886,208 @@ void ST7789(void *pvParameters)
 	lcdDrawFillRect(&dev, 20, 20, 30, 30, BLUE);
 #endif
 
+	// give plenty of time to enable the serial monitor
+#ifdef SVG_LOGGING
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+	WAIT;
+#endif
+
 	while(1) {
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "FillTest-SVG");
+#endif
 		FillTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "ColorBarTest-SVG");
+#endif
 		ColorBarTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
-
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "ArrowTest-SVG");
+#endif
 		ArrowTest(&dev, fx16G, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "LineTest-SVG");
+#endif
 		LineTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "CircleTest-SVG");
+#endif
 		CircleTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "RoundRectTest-SVG");
+#endif
 		RoundRectTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "RectAngleTest-SVG");
+#endif
 		RectAngleTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "TriangleTest-SVG");
+#endif
 		TriangleTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "DirectionTest-SVG");
+#endif
 		if (CONFIG_WIDTH >= 240) {
 			DirectionTest(&dev, fx24G, CONFIG_WIDTH, CONFIG_HEIGHT);
 		} else {
 			DirectionTest(&dev, fx16G, CONFIG_WIDTH, CONFIG_HEIGHT);
 		}
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "HorizontalTest-SVG");
+#endif
 		if (CONFIG_WIDTH >= 240) {
 			HorizontalTest(&dev, fx24G, CONFIG_WIDTH, CONFIG_HEIGHT);
 		} else {
 			HorizontalTest(&dev, fx16G, CONFIG_WIDTH, CONFIG_HEIGHT);
 		}
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "VerticalTest-SVG");
+#endif
 		if (CONFIG_WIDTH >= 240) {
 			VerticalTest(&dev, fx24G, CONFIG_WIDTH, CONFIG_HEIGHT);
 		} else {
 			VerticalTest(&dev, fx16G, CONFIG_WIDTH, CONFIG_HEIGHT);
 		}
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "FillRectTest-SVG");
+#endif
 		FillRectTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "ColorTest-SVG");
+#endif
 		ColorTest(&dev, CONFIG_WIDTH, CONFIG_HEIGHT);
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "CodeTestfx32G-SVG");
+#endif
 		CodeTest(&dev, fx32G, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "CodeTestfx32L-SVG");
+#endif
 		CodeTest(&dev, fx32L, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "BMPTest-SVG");
+#endif
 		char file[32];
 		strcpy(file, "/spiffs/image.bmp");
 		BMPTest(&dev, file, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 
 #ifndef CONFIG_IDF_TARGET_ESP32S2
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "JPEGTest-SVG");
+#endif
 		strcpy(file, "/spiffs/esp32.jpeg");
 		JPEGTest(&dev, file, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
 #endif
 
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "PNGTest-SVG");
+#endif
 		strcpy(file, "/spiffs/esp_logo.png");
 		PNGTest(&dev, file, CONFIG_WIDTH, CONFIG_HEIGHT);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
-
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingStart(&dev, ESP_LOG_INFO, "MultiFontTest-SVG");
+#endif
 		// Multi Font Test
 		uint16_t color;
 		uint8_t ascii[40];
@@ -1008,7 +1140,13 @@ void ST7789(void *pvParameters)
 			lcdDrawString(&dev, fx32M, xpos, ypos, ascii, color);
 		}
 		lcdSetFontDirection(&dev, 0);
+#ifdef SVG_LOGGING
+	    lcdSvgLoggingEnd(&dev, svg_cut_line);
+#endif
 		WAIT;
+#ifdef SVG_LOGGING
+	    break;
+#endif
 
 	} // end while
 
@@ -1019,9 +1157,10 @@ void ST7789(void *pvParameters)
 }
 
 
+
 void app_main(void)
 {
-	ESP_LOGI(TAG, "Initializing SPIFFS");
+    ESP_LOGI(TAG, "Initializing SPIFFS");
 
 	esp_vfs_spiffs_conf_t conf = {
 		.base_path = "/spiffs",

--- a/main/st7789.c
+++ b/main/st7789.c
@@ -258,9 +258,9 @@ void lcdDrawPixel(TFT_t * dev, uint16_t x, uint16_t y, uint16_t color){
 	if (y >= dev->_height) return;
 
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "<!-- %s --><rect fill=\"%s\" x=\"%d\" y=\"%d\" width=\"1\" height=\"1\" />",
-	            __FUNCTION__, rgb565_to_rgb(color), x, y);
-	    vTaskDelay(1);
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "<!-- %s --><rect fill=\"%s\" x=\"%d\" y=\"%d\" width=\"1\" height=\"1\" />",
+			__FUNCTION__, rgb565_to_rgb(color), x, y);
+		vTaskDelay(1);
 	}
 
 	uint16_t _x = x + dev->_offsetx;
@@ -285,30 +285,30 @@ void lcdDrawMultiPixels(TFT_t * dev, uint16_t x, uint16_t y, uint16_t size, uint
 	if (y >= dev->_height) return;
 
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    uint16_t color = colors[0];
-	    int run_length = 0;
-	    // These are horizontal renderings of colored pixels. We could just draw them like
-	    // individual pixels, but in practical cases there are likely to be significant
-	    // runs of pixels of the same color. Detect those and emit a single SVG line for
-	    // each such run. The degenerate case is randomly colored pixels with no two
-	    // consecutive pixels of the same color. For that case, we haven't lost anything
-	    // (in the emitted SVG) by looking for the runs.
-	    //
-	    // The library's sample app only uses lcdDrawMultiPixels() for the BMP/JPEG/PNG tests.
-	    for (int ii=0; ii<size; ++ii) {
-	        if (colors[ii] == color  &&  ii != (size-1)) {
-	            ++run_length;
-	            continue;
-	        } else {
-	            // detected a color change (or end of loop)
-	            // Since these are always horizontal lines, use a rect to make the math (and edge cases) simpler
-	            ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "<!-- %s --><rect fill=\"%s\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"1\" />",
-	                    __FUNCTION__, rgb565_to_rgb(color), (x+ii)-run_length, y, run_length);
-	            run_length = 1;
-	            color = colors[ii];
-	            vTaskDelay(1);
-	        }
-	    }
+		uint16_t color = colors[0];
+		int run_length = 0;
+		// These are horizontal renderings of colored pixels. We could just draw them like
+		// individual pixels, but in practical cases there are likely to be significant
+		// runs of pixels of the same color. Detect those and emit a single SVG line for
+		// each such run. The degenerate case is randomly colored pixels with no two
+		// consecutive pixels of the same color. For that case, we haven't lost anything
+		// (in the emitted SVG) by looking for the runs.
+		//
+		// The library's sample app only uses lcdDrawMultiPixels() for the BMP/JPEG/PNG tests.
+		for (int ii=0; ii<size; ++ii) {
+			if (colors[ii] == color  &&  ii != (size-1)) {
+				++run_length;
+				continue;
+			} else {
+				// detected a color change (or end of loop)
+				// Since these are always horizontal lines, use a rect to make the math (and edge cases) simpler
+				ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "<!-- %s --><rect fill=\"%s\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"1\" />",
+					__FUNCTION__, rgb565_to_rgb(color), (x+ii)-run_length, y, run_length);
+				run_length = 1;
+				color = colors[ii];
+				vTaskDelay(1);
+			}
+		}
 	}
 
 	uint16_t _x1 = x + dev->_offsetx;
@@ -337,15 +337,15 @@ void lcdDrawFillRect(TFT_t * dev, uint16_t x1, uint16_t y1, uint16_t x2, uint16_
 	if (y2 >= dev->_height) y2=dev->_height-1;
 
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    uint16_t minx = x1>x2 ? x2 : x1;
-	    uint16_t miny = y1>y2 ? y2 : y1;
-	    uint16_t maxx = x1>x2 ? x1 : x2;
-	    uint16_t maxy = x1>x2 ? y1 : y2;
-	    char *color_name = rgb565_to_rgb(color);
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
-	            "<!-- %s --><rect fill=\"%s\" stroke=\"%s\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" />",
-	            __FUNCTION__, color_name, color_name, minx, miny, maxx-minx, maxy-miny);
-	    vTaskDelay(1);
+		uint16_t minx = x1>x2 ? x2 : x1;
+		uint16_t miny = y1>y2 ? y2 : y1;
+		uint16_t maxx = x1>x2 ? x1 : x2;
+		uint16_t maxy = x1>x2 ? y1 : y2;
+		char *color_name = rgb565_to_rgb(color);
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
+			"<!-- %s --><rect fill=\"%s\" stroke=\"%s\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" />",
+			__FUNCTION__, color_name, color_name, minx, miny, maxx-minx, maxy-miny);
+		vTaskDelay(1);
 	}
 
 	ESP_LOGD(TAG,"offset(x)=%d offset(y)=%d",dev->_offsetx,dev->_offsety);
@@ -405,13 +405,13 @@ void lcdDrawLine(TFT_t * dev, uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2
 
 	esp_log_level_t old_level = ESP_LOG_NONE;
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    char *color_name = rgb565_to_rgb(color);
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
-	            "<!-- %s --><line fill=\"none\" stroke=\"%s\" x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\"/>",
-	            __FUNCTION__, color_name, x1, y1, x2, y2);
-	    vTaskDelay(1);
-	    old_level = dev->_svg_log_level;
-	    dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
+		char *color_name = rgb565_to_rgb(color);
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
+			"<!-- %s --><line fill=\"none\" stroke=\"%s\" x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\"/>",
+			__FUNCTION__, color_name, x1, y1, x2, y2);
+		vTaskDelay(1);
+		old_level = dev->_svg_log_level;
+		dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
 	}
 
 	/* direction of two point */
@@ -456,17 +456,17 @@ void lcdDrawLine(TFT_t * dev, uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2
 void lcdDrawRect(TFT_t * dev, uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color) {
 	esp_log_level_t old_level = ESP_LOG_NONE;
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    uint16_t minx = x1>x2 ? x2 : x1;
-	    uint16_t miny = y1>y2 ? y2 : y1;
-	    uint16_t maxx = x1>x2 ? x1 : x2;
-	    uint16_t maxy = x1>x2 ? y1 : y2;
-	    char *color_name = rgb565_to_rgb(color);
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
-	            "<!-- %s --><rect fill=\"none\" stroke=\"%s\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" />",
-	            __FUNCTION__, color_name, minx, miny, (maxx-minx)+1, (maxy-miny)+1);
-	    vTaskDelay(1);
-	    old_level = dev->_svg_log_level;
-	    dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
+		uint16_t minx = x1>x2 ? x2 : x1;
+		uint16_t miny = y1>y2 ? y2 : y1;
+		uint16_t maxx = x1>x2 ? x1 : x2;
+		uint16_t maxy = x1>x2 ? y1 : y2;
+		char *color_name = rgb565_to_rgb(color);
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
+			"<!-- %s --><rect fill=\"none\" stroke=\"%s\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" />",
+			__FUNCTION__, color_name, minx, miny, (maxx-minx)+1, (maxy-miny)+1);
+		vTaskDelay(1);
+		old_level = dev->_svg_log_level;
+		dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
 	}
 	lcdDrawLine(dev, x1, y1, x2, y1, color);
 	lcdDrawLine(dev, x2, y1, x2, y2, color);
@@ -513,11 +513,11 @@ void lcdDrawRectAngle(TFT_t * dev, uint16_t xc, uint16_t yc, uint16_t w, uint16_
 
 	esp_log_level_t old_level = ESP_LOG_NONE;
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "<!-- %s --><polygon fill=\"none\" stroke=\"%s\" points=\"%d,%d %d,%d %d,%d %d,%d\" />",
-	            __FUNCTION__, rgb565_to_rgb(color), x1, y1, x2, y2, x4, y4, x3, y3);
-	    vTaskDelay(1);
-	    old_level = dev->_svg_log_level;
-	    dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "<!-- %s --><polygon fill=\"none\" stroke=\"%s\" points=\"%d,%d %d,%d %d,%d %d,%d\" />",
+			__FUNCTION__, rgb565_to_rgb(color), x1, y1, x2, y2, x4, y4, x3, y3);
+		vTaskDelay(1);
+		old_level = dev->_svg_log_level;
+		dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
 	}
 
 	lcdDrawLine(dev, x1, y1, x2, y2, color);
@@ -587,12 +587,12 @@ void lcdDrawCircle(TFT_t * dev, uint16_t x0, uint16_t y0, uint16_t r, uint16_t c
 
 	esp_log_level_t old_level = ESP_LOG_NONE;
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
-	            "<!-- %s --><circle fill=\"none\" stroke=\"%s\" cx=\"%d\" cy=\"%d\" r=\"%d\" />",
-	            __FUNCTION__, rgb565_to_rgb(color), x0, y0, r);
-	    vTaskDelay(1);
-	    old_level = dev->_svg_log_level;
-	    dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
+			"<!-- %s --><circle fill=\"none\" stroke=\"%s\" cx=\"%d\" cy=\"%d\" r=\"%d\" />",
+			__FUNCTION__, rgb565_to_rgb(color), x0, y0, r);
+		vTaskDelay(1);
+		old_level = dev->_svg_log_level;
+		dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
 	}
 
 	x=0;
@@ -623,13 +623,13 @@ void lcdDrawFillCircle(TFT_t * dev, uint16_t x0, uint16_t y0, uint16_t r, uint16
 
 	esp_log_level_t old_level = ESP_LOG_NONE;
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    char *color_name = rgb565_to_rgb(color);
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
-	            "<!-- %s --><circle fill=\"%s\" stroke=\"%s\" cx=\"%d\" cy=\"%d\" r=\"%d\" />",
-	            __FUNCTION__, color_name, color_name, x0, y0, r);
-	    vTaskDelay(1);
-	    old_level = dev->_svg_log_level;
-	    dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
+		char *color_name = rgb565_to_rgb(color);
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
+			"<!-- %s --><circle fill=\"%s\" stroke=\"%s\" cx=\"%d\" cy=\"%d\" r=\"%d\" />",
+			__FUNCTION__, color_name, color_name, x0, y0, r);
+		vTaskDelay(1);
+		old_level = dev->_svg_log_level;
+		dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
 	}
 
 	x=0;
@@ -681,16 +681,16 @@ void lcdDrawRoundRect(TFT_t * dev, uint16_t x1, uint16_t y1, uint16_t x2, uint16
 
 	esp_log_level_t old_level = ESP_LOG_NONE;
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    uint16_t minx = x1>x2 ? x2 : x1;
-	    uint16_t miny = y1>y2 ? y2 : y1;
-	    uint16_t maxx = x1>x2 ? x1 : x2;
-	    uint16_t maxy = x1>x2 ? y1 : y2;
-	    char *color_name = rgb565_to_rgb(color);
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
-	            "<!-- %s --><rect stroke=\"%s\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" r=\"%d\" />",
-	            __FUNCTION__, color_name, minx, miny, (maxx-minx)+1, (maxy-miny)+1, r);
-	    old_level = dev->_svg_log_level;
-	    dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
+		uint16_t minx = x1>x2 ? x2 : x1;
+		uint16_t miny = y1>y2 ? y2 : y1;
+		uint16_t maxx = x1>x2 ? x1 : x2;
+		uint16_t maxy = x1>x2 ? y1 : y2;
+		char *color_name = rgb565_to_rgb(color);
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
+			"<!-- %s --><rect stroke=\"%s\" x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" r=\"%d\" />",
+			__FUNCTION__, color_name, minx, miny, (maxx-minx)+1, (maxy-miny)+1, r);
+		old_level = dev->_svg_log_level;
+		dev->_svg_log_level = ESP_LOG_NONE;  // to skip the draw pixel stuff
 	}
 
 	do{
@@ -796,11 +796,11 @@ static size_t color_name_buf_len = sizeof(color_name_buf);
 // Don't make overlapped calls to this function because
 // the returned string might change when you're not expecting it.
 char * rgb565_to_rgb(uint16_t color) {
-    uint16_t r = (color >> 8) & 0xF8;
-    uint16_t g = (color >> 3) & 0xFC;
-    uint16_t b = (color << 3) & 0xF8;
-    snprintf(color_name_buf, color_name_buf_len, "rgb(%d,%d,%d)", r, g, b);
-    return color_name_buf;
+	uint16_t r = (color >> 8) & 0xF8;
+	uint16_t g = (color >> 3) & 0xFC;
+	uint16_t b = (color << 3) & 0xF8;
+	snprintf(color_name_buf, color_name_buf_len, "rgb(%d,%d,%d)", r, g, b);
+	return color_name_buf;
 }
 
 // Draw ASCII character
@@ -1101,22 +1101,22 @@ void lcdInversionOn(TFT_t * dev) {
 // For simplicity, you probably also want to turn off the ANSI color
 // coding of log output in your ESP-IDF project config settings.
 void lcdSvgLoggingStart(TFT_t * dev, esp_log_level_t level, const char *tag) {
-    dev->_svg_log_level = level;
-    dev->_svg_log_tag = tag;
+	dev->_svg_log_level = level;
+	dev->_svg_log_tag = tag;
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
-	            "<svg version=\"1.1\" width=\"%d\" height=\"%d\" viewBox=\"0 0 %d %d\" xmlns=\"http://www.w3.org/2000/svg\">",
-	            dev->_width, dev->_height, dev->_width, dev->_height);
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag,
+			"<svg version=\"1.1\" width=\"%d\" height=\"%d\" viewBox=\"0 0 %d %d\" xmlns=\"http://www.w3.org/2000/svg\">",
+			dev->_width, dev->_height, dev->_width, dev->_height);
 	}
 }
 
 // You must call this to properly end SVG logging.
 void lcdSvgLoggingEnd(TFT_t * dev, char *cut_line) {
 	if (dev->_svg_log_level != ESP_LOG_NONE) {
-	    ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "</svg>");
-	    if (cut_line != NULL) {
-	        ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "%s", cut_line);
-	    }
+		ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "</svg>");
+		if (cut_line != NULL) {
+			ESP_LOG_LEVEL(dev->_svg_log_level, dev->_svg_log_tag, "%s", cut_line);
+		}
 	}
-    dev->_svg_log_level = ESP_LOG_NONE;
+	dev->_svg_log_level = ESP_LOG_NONE;
 }

--- a/main/st7789.h
+++ b/main/st7789.h
@@ -1,6 +1,7 @@
 #ifndef MAIN_ST7789_H_
 #define MAIN_ST7789_H_
 
+#include "esp_log.h"
 #include "driver/spi_master.h"
 #include "fontx.h"
 

--- a/main/st7789.h
+++ b/main/st7789.h
@@ -34,6 +34,8 @@ typedef struct {
 	int16_t _dc;
 	int16_t _bl;
 	spi_device_handle_t _SPIHandle;
+	esp_log_level_t _svg_log_level;
+	const char * _svg_log_tag;
 } TFT_t;
 
 void spi_master_init(TFT_t * dev, int16_t GPIO_MOSI, int16_t GPIO_SCLK, int16_t GPIO_CS, int16_t GPIO_DC, int16_t GPIO_RESET, int16_t GPIO_BL);
@@ -63,6 +65,7 @@ void lcdDrawRoundRect(TFT_t * dev, uint16_t x1, uint16_t y1, uint16_t x2, uint16
 void lcdDrawArrow(TFT_t * dev, uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint16_t w, uint16_t color);
 void lcdDrawFillArrow(TFT_t * dev, uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint16_t w, uint16_t color);
 uint16_t rgb565_conv(uint16_t r, uint16_t g, uint16_t b);
+char * rgb565_to_rgb(uint16_t color);  // static result buffer
 int lcdDrawChar(TFT_t * dev, FontxFile *fx, uint16_t x, uint16_t y, uint8_t ascii, uint16_t color);
 int lcdDrawString(TFT_t * dev, FontxFile *fx, uint16_t x, uint16_t y, uint8_t * ascii, uint16_t color);
 int lcdDrawCode(TFT_t * dev, FontxFile *fx, uint16_t x,uint16_t y,uint8_t code,uint16_t color);
@@ -77,5 +80,8 @@ void lcdBacklightOff(TFT_t * dev);
 void lcdBacklightOn(TFT_t * dev);
 void lcdInversionOff(TFT_t * dev);
 void lcdInversionOn(TFT_t * dev);
+
+void lcdSvgLoggingStart(TFT_t * dev, esp_log_level_t level, const char *tag);
+void lcdSvgLoggingEnd(TFT_t * dev, char * cut_line);
 #endif /* MAIN_ST7789_H_ */
 


### PR DESCRIPTION
I wanted to make some screenshots of some things I was doing with this graphics package, 
so I implemented a way to get SVG output. If you find it interesting, feel free to add it
to the library (or any similar driver libraries you have).

SVG logging sends equivalent SVG directives to the ESP log (usually uart0).
It logs at the logging level and with the logging tag specified. That
should make it straightforward to use text tools to carve the actual SVG
out of the log. There is an optional "cut line" argument to the lcdSvgLoggingEnd.
If provided, it is logged as-is and could be used to automatically separate
multiple chunks from the overall output.

There is no inherent overall background color. If you want one, you
should start with lcdFillScreen() within the SVG logging.

SVG output can be quite verbose (especially for things like text that are
drawn a pixel at a time). It also slows things down a huge amount. In fact,
it makes things so slow that there are task delays of 1 tick sprinkled
throughout to avoid tripping the task watchdog timer.
